### PR TITLE
some enhancements for the site extension

### DIFF
--- a/SiteController.php
+++ b/SiteController.php
@@ -43,6 +43,11 @@ class SiteController extends OntoWiki_Controller_Component
     private $_resourceUri = null;
 
     /**
+     * relative Path to the extension template folder
+     */
+    private $_relativeTemplatePath = 'templates';
+    
+    /**
      * The site id which is part of the request URI as well as the template structure
      *
      * @var string|null
@@ -54,6 +59,7 @@ class SiteController extends OntoWiki_Controller_Component
         parent::init();
         $this->_helper->viewRenderer->setNoRender();
         $this->_helper->layout()->disableLayout();
+        $this->_relativeTemplatePath = $this->_owApp->extensionManager->getExtensionConfig('site')->templates;
     }
 
     /*
@@ -106,7 +112,7 @@ class SiteController extends OntoWiki_Controller_Component
             }
 
             $moduleTemplatePath = $this->_componentRoot
-                                . 'sites'
+                                . $this->_relativeTemplatePath
                                 . DIRECTORY_SEPARATOR
                                 . $this->_privateConfig->defaultSite
                                 . DIRECTORY_SEPARATOR
@@ -163,8 +169,8 @@ class SiteController extends OntoWiki_Controller_Component
             'wikiBaseUrl'       => $this->_owApp->getUrlBase(),
             'themeUrlBase'      => $this->view->themeUrlBase,
             'libraryUrlBase'    => $this->view->libraryUrlBase,
-            'basePath'          => sprintf('%ssites/%s', $this->_componentRoot, $this->_site),
-            'baseUri'           => sprintf('%ssites/%s', $this->_componentUrlBase, $this->_site),
+            'basePath'          => sprintf('%s%s/%s', $this->_componentRoot, $this->_relativeTemplatePath, $this->_site),
+            'baseUri'           => sprintf('%s%s/%s', $this->_componentUrlBase, $this->_relativeTemplatePath, $this->_site),
             'context'           => $this->moduleContext,
             'namespaces'        => $namespaces,
             'model'             => $this->_model,
@@ -196,7 +202,7 @@ class SiteController extends OntoWiki_Controller_Component
             if (!Erfurt_Uri::check($siteConfig['model'])) {
                 $site = $this->_privateConfig->defaultSite;
                 $root = $this->getComponentHelper()->getComponentRoot();
-                $configFilePath = sprintf('%ssites/%s/%s', $root, $site, SiteHelper::SITE_CONFIG_FILENAME);
+                $configFilePath = sprintf('%s%s/%s/%s', $root, $this->_relativeTemplatePath, $site, SiteHelper::SITE_CONFIG_FILENAME);
                 throw new OntoWiki_Exception(
                     'No model selected! Please, configure a site model by setting the option '
                     . '"model=..." in "' . $configFilePath . '" or specify parameter m in the URL.'

--- a/SiteHelper.php
+++ b/SiteHelper.php
@@ -240,8 +240,9 @@ class SiteHelper extends OntoWiki_Component_Helper
             $this->_siteConfig = array();
             $site = $this->_privateConfig->defaultSite;
 
+            $relativeTemplatePath = OntoWiki::getInstance()->extensionManager->getExtensionConfig('site')->templates;
             // load the site config
-            $configFilePath = sprintf('%s/sites/%s/%s', $this->getComponentRoot(), $site, self::SITE_CONFIG_FILENAME);
+            $configFilePath = sprintf('%s/%s/%s/%s', $this->getComponentRoot(), $relativeTemplatePath, $site, self::SITE_CONFIG_FILENAME);
             if (is_readable($configFilePath)) {
                 if ($config = parse_ini_file($configFilePath, true)) {
                     $this->_siteConfig = $config;

--- a/helpers/Img.php
+++ b/helpers/Img.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of the {@link http://ontowiki.net OntoWiki} project.
  *
- * @copyright Copyright (c) 2011, {@link http://aksw.org AKSW}
+ * @copyright Copyright (c) 2006-2013, {@link http://aksw.org AKSW}
  * @license http://opensource.org/licenses/gpl-license.php GNU General Public License (GPL)
  */
 
@@ -26,7 +26,7 @@ class Site_View_Helper_Img extends Zend_View_Helper_Abstract implements Site_Vie
     /*
      * the list of known image properties
      */
-    private $properties = array(
+    private $_properties = array(
         'http://xmlns.com/foaf/0.1/depiction',
         'http://xmlns.com/foaf/0.1/logo',
         'http://xmlns.com/foaf/0.1/img',
@@ -54,7 +54,7 @@ class Site_View_Helper_Img extends Zend_View_Helper_Abstract implements Site_Vie
         $extManager  = $owapp->extensionManager;
 
         // check for options and assign local vars or null
-        $src      = (isset($options['src']))    ? (string) $options['src']         : null;
+        $src      = (isset($options['src']))    ? (string)$options['src']         : null;
         $class    = (isset($options['class']))  ? ' class="'.$options['class'].'"' : '';
         $alt      = (isset($options['alt']))    ? ' alt="'.$options['alt'].'"'     : '';
         $filter   = (isset($options['filter'])) ? $options['filter']               : null;
@@ -64,8 +64,8 @@ class Site_View_Helper_Img extends Zend_View_Helper_Abstract implements Site_Vie
 
         // choose, which uri to use: option over helper default over view value
         $uri = (isset($this->resourceUri))           ? $this->resourceUri : null;
-        $uri = (isset($options['selectedResource'])) ? (string) $options['selectedResource'] : $uri;
-        $uri = (isset($options['uri']))              ? (string) $options['uri'] : $uri;
+        $uri = (isset($options['selectedResource'])) ? (string)$options['selectedResource'] : $uri;
+        $uri = (isset($options['uri']))              ? (string)$options['uri'] : $uri;
         // in case qname is given, transform to full URI
         $uri = Erfurt_Uri::getFromQnameOrUri($uri, $model);
 
@@ -73,7 +73,7 @@ class Site_View_Helper_Img extends Zend_View_Helper_Abstract implements Site_Vie
         if ($src == null) {
             // choose, which properties to use for lookup (todo: allow multple properties)
             $properties = (isset($options['property'])) ? array( $options['property']) : null;
-            $properties = (!$properties) ? $this->properties : $properties;
+            $properties = (!$properties) ? $this->_properties : $properties;
 
             // validate each given property
             foreach ($properties as $key => $value) {
@@ -101,7 +101,17 @@ class Site_View_Helper_Img extends Zend_View_Helper_Abstract implements Site_Vie
             }
 
             if ($imgProperty != null) {
-                $imgSrc = $description[$imgProperty][0]['value'];
+                //search for language tag
+                foreach ($description[$imgProperty] as $literalNumber => $literal) {
+                    $currentLanguage = OntoWiki::getInstance()->getConfig()->languages->locale;
+                    if (isset($literal['lang']) && $currentLanguage == $literal['lang']) {
+                        $imgSrc = $description[$imgProperty][$literalNumber]['value'];
+                        break;
+                    }
+                }
+                if (!isset($imgSrc)) {
+                    $imgSrc = $description[$imgProperty][0]['value'];
+                }
             } else {
                 // we do not have an image src
                 return '';
@@ -143,6 +153,6 @@ class Site_View_Helper_Img extends Zend_View_Helper_Abstract implements Site_Vie
     public function setView(Zend_View_Interface $view)
     {
         $this->view = $view;
-        $this->resourceUri  = (string) $view->resourceUri;
+        $this->resourceUri  = (string)$view->resourceUri;
     }
 }

--- a/helpers/Literal.php
+++ b/helpers/Literal.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of the {@link http://ontowiki.net OntoWiki} project.
  *
- * @copyright Copyright (c) 2011, {@link http://aksw.org AKSW}
+ * @copyright Copyright (c) 2006-2013, {@link http://aksw.org AKSW}
  * @license http://opensource.org/licenses/gpl-license.php GNU General Public License (GPL)
  */
 
@@ -62,8 +62,8 @@ class Site_View_Helper_Literal extends Zend_View_Helper_Abstract implements Site
 
         // choose, which uri to use: option over helper default over view value
         $uri = (isset($this->resourceUri))           ? $this->resourceUri : null;
-        $uri = (isset($options['selectedResource'])) ? (string) $options['selectedResource'] : $uri;
-        $uri = (isset($options['uri']))              ? (string) $options['uri'] : $uri;
+        $uri = (isset($options['selectedResource'])) ? (string)$options['selectedResource'] : $uri;
+        $uri = (isset($options['uri']))              ? (string)$options['uri'] : $uri;
         $uri = Erfurt_Uri::getFromQnameOrUri($uri, $model);
 
         // choose, which properties to use (todo: allow multple properties)
@@ -96,7 +96,17 @@ class Site_View_Helper_Literal extends Zend_View_Helper_Abstract implements Site
         // filter and render the (first) literal value of the main property
         // TODO: striptags and tidying as extension
         if ($mainProperty) {
-            $firstLiteral = $description[$mainProperty][0];
+            //search for language tag
+            foreach ($description[$mainProperty] as $literalNumber => $literal) {
+                $currentLanguage = OntoWiki::getInstance()->getConfig()->languages->locale;
+                if (isset($literal['lang']) && $currentLanguage == $literal['lang']) {
+                    $firstLiteral = $description[$mainProperty][$literalNumber];
+                    break;
+                }
+            }
+            if (!isset($firstLiteral)) {
+                $firstLiteral = $description[$mainProperty][0];
+            }
             $content = $firstLiteral['value'];
 
             if ($array) {
@@ -138,7 +148,7 @@ class Site_View_Helper_Literal extends Zend_View_Helper_Abstract implements Site
     public function setView(Zend_View_Interface $view)
     {
         $this->view = $view;
-        $this->resourceUri  = (string) $view->resourceUri;
+        $this->resourceUri  = (string)$view->resourceUri;
     }
 
 }

--- a/helpers/Table.php
+++ b/helpers/Table.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * This file is part of the {@link http://ontowiki.net OntoWiki} project.
+ *
+ * @copyright Copyright (c) 2006-2013, {@link http://aksw.org AKSW}
+ * @license http://opensource.org/licenses/gpl-license.php GNU General Public License (GPL)
+ */
+
+/**
+ * OntoWiki Table view helper
+ *
+ * returns the content of a specific property of a given resource as an RDFa
+ * annotated tag with (optional) given css classes and other parameters
+ * this helper is usable as {{literal ...}} markup in combination with
+ * ExecuteHelperMarkup
+ *
+ * @category OntoWiki
+ * @package  OntoWiki_extensions_components_site
+ */
+class Site_View_Helper_Table extends Zend_View_Helper_Abstract implements Site_View_Helper_MarkupInterface
+{
+    /*
+     * current view, injected with setView from Zend
+     */
+    public $view;
+
+    public $contentProperties = array(
+        'http://ns.ontowiki.net/SysOnt/Site/tableContent',
+    );
+
+    /*
+     * the main tah method, mentioned parameters are:
+     * - uri      - which resource the literal is from (empty means selected * Resource)
+     * - property - qname/uri of property to use
+     * - class    - css class
+     * - tag      - the used tag, e.g. span
+     * - prefix   - string at the beginning
+     * - suffix   - string at the end
+     * - iprefix  - string between tag and content at the beginning
+     * - isuffix  - string betwee content and tag at the end
+     */
+    public function table($options = array())
+    {
+        $model       = OntoWiki::getInstance()->selectedModel;
+        $titleHelper = new OntoWiki_Model_TitleHelper($model);
+
+        // check for options and assign local vars or default values
+        $class   = (isset($options['class']))   ? $options['class']   : '';
+        $id      = (isset($options['id']))      ? $options['id']      : '';
+        $tag     = (isset($options['tag']))     ? $options['tag']     : 'span';
+        $prefix  = (isset($options['prefix']))  ? $options['prefix']  : '';
+        $suffix  = (isset($options['suffix']))  ? $options['suffix']  : '';
+        $iprefix = (isset($options['iprefix'])) ? $options['iprefix'] : '';
+        $isuffix = (isset($options['isuffix'])) ? $options['isuffix'] : '';
+
+        // choose, which uri to use: option over helper default over view value
+        $uri = (isset($this->resourceUri))           ? $this->resourceUri : null;
+        $uri = (isset($options['selectedResource'])) ? (string)$options['selectedResource'] : $uri;
+        $uri = (isset($options['uri']))              ? (string)$options['uri'] : $uri;
+        $uri = Erfurt_Uri::getFromQnameOrUri($uri, $model);
+
+        // choose, which properties to use (todo: allow multple properties)
+        $contentProperties = (isset($options['property'])) ? array( $options['property']) : null;
+        $contentProperties = (!$contentProperties) ? $this->contentProperties : $contentProperties;
+
+        foreach ($contentProperties as $key => $value) {
+            try {
+                $validatedValue = Erfurt_Uri::getFromQnameOrUri($value, $model);
+                $contentProperties[$key] = $validatedValue;
+            } catch (Exception $e) {
+                unset($contentProperties[$key]);
+            }
+        }
+
+        // create description from resource URI
+        $resource     = new OntoWiki_Resource($uri, $model);
+        $description  = $resource->getDescription();
+        $description  = $description[$uri];
+
+        // get the table size
+        $tableRows = 0; // the URI of the main content property
+        $tableColumns = 0; // the URI of the main content property
+        foreach ($contentProperties as $contentProperty) {
+            if (isset($description[$contentProperty . 'Rows'])) {
+                $tableRows = (int)$description[$contentProperty . 'Rows'][0]['value'];
+            }
+            if (isset($description[$contentProperty . 'Columns'])) {
+                $tableColumns = (int)$description[$contentProperty . 'Columns'][0]['value'];
+            }
+            if (null != $tableRows && null != $tableColumns) {
+                $mainProperty = $contentProperty;
+                break;
+            }
+        }
+        $content = '';
+        // filter and render the table
+        if (0 < $tableRows && 0 < $tableColumns) {
+            $content .= '<table id=' . $id . '><thead>';
+            for ($row = 1; $row <= $tableRows; $row++) {
+                $content .= '<tr id="R' . $row . '">';
+                for ($column = 1; $column <= $tableColumns; $column++) {
+                    $content .= (1 == $row ? '<th' : '<td') . ' id="R' . $row . 'C' . $column . '">';
+                    $currentMainProperty = $mainProperty . 'R' . $row . 'C' . $column;
+                    unset($firstLiteral);
+                    // search for language tag
+                    foreach ($description[$currentMainProperty] as $literalNumber => $literal) {
+                        $currentLanguage = OntoWiki::getInstance()->getConfig()->languages->locale;
+                        if (isset($literal['lang']) && $currentLanguage == $literal['lang']) {
+                            $firstLiteral = $description[$currentMainProperty][$literalNumber];
+                            break;
+                        }
+                    }
+                    if (!isset($firstLiteral)) {
+                        $firstLiteral = $description[$currentMainProperty][0];
+                    }
+                    $cellContent = $firstLiteral['value'];
+        
+                    // execute the helper markup on the content (after the extensions)
+                    $cellContent = $this->view->executeHelperMarkup($cellContent);
+        
+                    // filter by using available extensions
+                    if (isset($firstLiteral['datatype'])) {
+                        $datatype = $firstLiteral['datatype'];
+                        $cellContent = $this->view->displayLiteralPropertyValue($cellContent, $currentMainProperty, $datatype);
+                    } else {
+                        $cellContent = $this->view->displayLiteralPropertyValue($cellContent, $currentMainProperty);
+                    }
+        
+                    $curie = $this->view->curie($currentMainProperty);
+                    $content .= "$prefix<$tag class='$class' property='$curie'>$iprefix$cellContent$isuffix</$tag>$suffix";
+                    $content .= 1 == $row ? '</th>' : '</td>';
+                }
+                $content .= '</tr>';
+                $content .= (1 == $row ? '</thead><tbody>' : '');
+            }
+            $content .= '</tbody></table>';
+        }
+        return $content;
+
+    }
+
+    /*
+     * view setter (dev zone article: http://devzone.zend.com/article/3412)
+     */
+    public function setView(Zend_View_Interface $view)
+    {
+        $this->view = $view;
+        $this->resourceUri  = (string)$view->resourceUri;
+    }
+
+}


### PR DESCRIPTION
with the dispedia development i have made some enhancements for this extension, here is a little overview
- first I added language support for _literal_ and _img_ helper. It's useful if you have different language on the website and the extension should use the statement in the selected language
- the second feature is, that the _sites_ folder are now really changeable. Before you was able to change the folder in the doap file, but the references to this folder are still alive, because the are hard coded in the controller, now you are able to really change the folder to any place you want (also outside the extension)
- the third one is a table helper, so you can add specific statements to the site model and the helper generate a table from this statements (also with language support, like the first feature). To use this you have a main property, like this
  `http://ns.ontowiki.net/SysOnt/Site/tableContent`, then the cells were filled with the content of the following properties

```
http://ns.ontowiki.net/SysOnt/Site/tableContentR1C1
http://ns.ontowiki.net/SysOnt/Site/tableContentR2C1
http://ns.ontowiki.net/SysOnt/Site/tableContentR1C2
```

and the size will be set by

```
http://ns.ontowiki.net/SysOnt/Site/tableContentRows
http://ns.ontowiki.net/SysOnt/Site/tableContentColumns
```

With this you can generate a table and can change the content and the size dynamically. I don't know if this is a correct or good semantic representation of a table, but anyway i needed a table one the website.
If you want to look at a example, look at www.dispedia.de.

Maybe you want to include some of this features, feel free to do it. :)
