### PR TITLE
Config paramter for folder of resource type templates

### DIFF
--- a/SiteHelper.php
+++ b/SiteHelper.php
@@ -222,7 +222,7 @@ class SiteHelper extends OntoWiki_Component_Helper
         if (null === $this->_siteConfig) {
             $this->_siteConfig = array();
             $site = $this->_privateConfig->defaultSite;
-
+            $typesfolder = $this->_privateConfig->subfolderTypes;
             $relativeTemplatePath = OntoWiki::getInstance()->extensionManager->getExtensionConfig('site')->templates;
             // load the site config
             $configFilePath = sprintf('%s/%s/%s/%s', $this->getComponentRoot(), $relativeTemplatePath, $site, self::SITE_CONFIG_FILENAME);
@@ -234,6 +234,11 @@ class SiteHelper extends OntoWiki_Component_Helper
 
             // add the site id to the config in order to allow correct URIs
             $this->_siteConfig['id'] = $site;
+            
+            // subfolder for resource type templates
+            if (!isset($this->_siteConfig['subfolderTypes'])) {
+                $this->_siteConfig['subfolderTypes'] = $typesfolder;
+            }
         }
 
         return $this->_siteConfig;

--- a/doap.n3
+++ b/doap.n3
@@ -33,6 +33,7 @@
   owconfig:hasModule :CacheViewer;
 
   :defaultSite "example" ;
+  :subfolderTypes "types" ;
   doap:release :v1-0 .
 
 :v1-0 a doap:Version ;
@@ -41,6 +42,7 @@
   doap:file-release <https://github.com/AKSW/site.ontowiki/zipball/master> .
 
 :defaultSite rdfs:label "The site identifier which is used for the site rendering".
+:subfolderTypes rdfs:label "Local name of subfolder in the templates directory, holding templates for resource types.".
 
 <http://aksw.org/SebastianTramp> a foaf:Person;
   foaf:name "Sebastian Tramp";

--- a/helpers/Renderx.php
+++ b/helpers/Renderx.php
@@ -156,8 +156,21 @@ class Site_View_Helper_Renderx extends Zend_View_Helper_Abstract implements Site
             }
         }
 
+        // set folder for resource type templates
+        $siteConfig = $this->view->templateData['siteConfig'];
+        $foldernameTypes = 'types'; // Fallback for old behaviour
+        if (isset($siteConfig['subfolderTypes'])) {
+            // default setting
+            $foldernameTypes = $siteConfig['subfolderTypes'];
+        }
+        if (isset($siteConfig['private']) && isset($siteConfig['private']['subfolderTypes'])) {
+            // private user setting
+            $foldernameTypes = $siteConfig['private']['subfolderTypes'];
+        }
+        
+        // path name of template
         if ($templateName != null) {
-            $this->_template = $this->view->siteId .'/types/'. $templateName .'.phtml';
+            $this->_template = $this->view->siteId . str_replace('//', '/', '/' . $foldernameTypes . '/') . $templateName .'.phtml';
             return $this->_template;
         } else {
             return false;


### PR DESCRIPTION
Set the foldername of the resource type templates via config parameter. This was done before hardcoded (sitename/types/...). It is still "types" when not configured otherwise.
