### PR TITLE
fixed php fatal error call to unknown function getComponentHelper()

### DIFF
--- a/SiteHelper.php
+++ b/SiteHelper.php
@@ -657,8 +657,8 @@ ORDER BY DESC(?modified)';
             // TODO: what if no site model configured?
             if (!Erfurt_Uri::check($siteConfig['model'])) {
                 $site = $this->_privateConfig->defaultSite;
-                $root = $this->getComponentHelper()->getComponentRoot();
-                $configFilePath = sprintf('%s%s/%s/%s', $root, $this->_relativeTemplatePath, $site, SiteHelper::SITE_CONFIG_FILENAME);
+                $root = $this->getComponentRoot();
+                $configFilePath = sprintf('%s%s%s/%s', $root, $this->_relativeTemplatePath, $site, SiteHelper::SITE_CONFIG_FILENAME);
                 throw new OntoWiki_Exception(
                     'No model selected! Please, configure a site model by setting the option '
                     . '"model=..." in "' . $configFilePath . '" or specify parameter m in the URL.'

--- a/SiteHelper.php
+++ b/SiteHelper.php
@@ -81,7 +81,8 @@ class SiteHelper extends OntoWiki_Component_Helper
 
     public function init()
     {
-        $this->_relativeTemplatePath = $this->_owApp->extensionManager->getExtensionConfig('site')->templates;
+        //removing possible trailing slash with rtrim
+        $this->_relativeTemplatePath = rtrim($this->_owApp->extensionManager->getExtensionConfig('site')->templates, '/');
     }
 
     public function onAnnounceWorker($event)
@@ -657,7 +658,7 @@ ORDER BY DESC(?modified)';
             // TODO: what if no site model configured?
             if (!Erfurt_Uri::check($siteConfig['model'])) {
                 $site = $this->_privateConfig->defaultSite;
-                $root = $this->getComponentHelper()->getComponentRoot();
+                $root = $this->getComponentRoot();
                 $configFilePath = sprintf('%s%s/%s/%s', $root, $this->_relativeTemplatePath, $site, SiteHelper::SITE_CONFIG_FILENAME);
                 throw new OntoWiki_Exception(
                     'No model selected! Please, configure a site model by setting the option '


### PR DESCRIPTION
getComponentHelper was unknown to php, $this->getComponentRoot() correctly displays root;

correct ontowiki exception is now printed on debug mode when no model is selected.
